### PR TITLE
Update UCO Address and name

### DIFF
--- a/modules/statics/src/coins.ts
+++ b/modules/statics/src/coins.ts
@@ -7834,9 +7834,9 @@ export const coins = CoinMap.fromCoins([
   erc20(
     '243053c9-e331-48f8-9f99-7af4e4f080c6',
     'uco',
-    'UnirisToken',
+    'Archethic Universal Coin',
     18,
-    '0x8a3d77e9d6968b780564936d15b09805827c21fa',
+    '0x1A688D3d294ee7BcC1f59011DE93d608Dc21c377',
     UnderlyingAsset.UCO
   ),
   erc20(


### PR DESCRIPTION

Following the token migration (cf https://x.com/archethic/status/1843257497555284442) here is the new address and name of Archethic UCO Token (previously Uniris Coin)

New address: https://etherscan.io/address/0x1A688D3d294ee7BcC1f59011DE93d608Dc21c377

